### PR TITLE
Setting relatime and renaming a function to be more specific.

### DIFF
--- a/site-packages/integralstor_utils/cifs.py
+++ b/site-packages/integralstor_utils/cifs.py
@@ -17,9 +17,9 @@ def update_auth_method(security):
             raise Exception(err)
         cl = []
         if not d:
-            #Insert a default entry before they modify the settings..
+            # Insert a default entry before they modify the settings..
             cl.append(["insert into samba_global_common (id, workgroup, netbios_name, security, include_homes_section) values (?, ?, ?, ?, ?)",
-                   (1, 'workgroup', 'netbios_name', security, True,)])
+                       (1, 'workgroup', 'netbios_name', security, True,)])
         else:
             cl.append(
                 ["update samba_global_common set security='%s' where id=1" % security])
@@ -401,13 +401,9 @@ def generate_common_global_section(f, d, extra_global_param_lines=None):
                 if 'ad_schema_mode' in d:
                     f.write("  idmap config %s:schema_mode = %s\n" %
                             (d["workgroup"].upper(), d["ad_schema_mode"]))
-            #f.write("  idmap config %s:range = %d-%d\n"%(d["workgroup"].upper(), d["id_map_min"], d["id_map_max"]))
-                f.write("  idmap config %s:range = 16777216-33554431\n" %
-                        d["workgroup"].upper())
                 f.write("  idmap config %s:base_rid = 0\n" %
                         d["workgroup"].upper())
-        else:
-            f.write("  idmap config *:range = 16777216-33554431\n")
+        f.write("  idmap config *:range = 16777216-33554431\n")
         if extra_global_param_lines:
             for line in extra_global_param_lines:
                 f.write("  %s\n" % line)

--- a/site-packages/integralstor_utils/zfs.py
+++ b/site-packages/integralstor_utils/zfs.py
@@ -861,7 +861,7 @@ def get_property(target, prop_name):
         return d, None
 
 
-def update_property(name, prop_name, prop_value):
+def update_dataset_zvol_property(name, prop_name, prop_value):
     try:
         if (not name) or (not prop_name) or (not prop_value):
             raise Exception('Required parameters not passed')
@@ -1328,7 +1328,8 @@ def update_default_pool_quota(pool_name):
         # print 'quota str', quota_str
         # print 'Setting ZFS pool quota..'
         if quota_str:
-            ret, err = update_property(pool_name, 'quota', quota_str)
+            ret, err = update_dataset_zvol_property(
+                pool_name, 'quota', quota_str)
             # print 'setting pool quota ', ret, err
             if err:
                 raise Exception(err)
@@ -1414,12 +1415,18 @@ def create_pool(pool_name, type, data_vdev_list, log_vdev=None, dedup=False):
         if err:
             raise Exception('Error creating the pool : %s' % err)
 
-        ret, err = update_property(pool_name, 'xattr', 'sa')
+        ret, err = update_dataset_zvol_property(pool_name, 'xattr', 'sa')
         if err:
             raise Exception(
                 'Error setting extended attributes for the pool : %s' % err)
 
-        ret, err = update_property(pool_name, 'acltype', 'posixacl')
+        ret, err = update_dataset_zvol_property(pool_name, 'relatime', 'on')
+        if err:
+            raise Exception(
+                'Error setting extended attributes for the pool : %s' % err)
+
+        ret, err = update_dataset_zvol_property(
+            pool_name, 'acltype', 'posixacl')
         if err:
             raise Exception('Error turning on ACLs for the pool : %s' % err)
 


### PR DESCRIPTION
Set the relatime for root dataset during pool creation (integralstor issue 222). Change the name of update_property to update_dataset_zvol_property to be more specific