### PR TITLE
Update interface/connection status

### DIFF
--- a/site-packages/integralstor_utils/networking.py
+++ b/site-packages/integralstor_utils/networking.py
@@ -788,7 +788,16 @@ def get_interface_up_status(if_name):
         if init_type not in ['systemd', 'init']:
             raise Exception("No Systemd or Init found.")
         elif init_type == 'systemd':
-            cmd = 'nmcli -t con show %s | grep -ie general.state | cut -d : -f 2' % if_name
+            bid, err = get_bonding_info_all()
+            if err:
+                raise Exception(err)
+            cmd = ''
+            if if_name in bid['by_slave']:
+                cmd = 'nmcli -t con show %s-%s | grep -ie general.state | cut -d : -f 2' % (
+                    bid['by_slave'][if_name], if_name)
+            else:
+                cmd = 'nmcli -t con show %s | grep -ie general.state | cut -d : -f 2' % if_name
+
             ret, err = command.get_command_output(cmd, shell=True)
             # if err, status remains as 'unknown'
             if ret and ret[0] == 'activated':
@@ -979,7 +988,7 @@ def update_interface_ip(if_name, d):
             cmd_assert_con = 'nmcli con show %s' % if_name
             assert_con, err = command.get_command_output(cmd_assert_con)
             if err:
-                cmd_con_create = 'ncmli con add type ethernet con-name %s ifname %s' % (
+                cmd_con_create = 'nmcli con add type ethernet con-name %s ifname %s' % (
                     if_name, if_name)
                 r, err1 = command.get_command_output(cmd_con_create)
                 if err1:


### PR DESCRIPTION
With nmcli and init both in place, connections on an interface and
interface as such must be handled appropriately. With nmcli, connections
are brought up/down. With Init, interfaces are brought up/down. An
interface can be associated with multiple connections through nmcli.

Signed-off-by: six-k <ramsri.hp@gmail.com>