### PR TITLE
Set MTU for systemd network interfaces

### DIFF
--- a/site-packages/integralstor_utils/networking.py
+++ b/site-packages/integralstor_utils/networking.py
@@ -952,14 +952,20 @@ def update_interface_ip(if_name, d):
             if_nm = if_nm.split("/")
             if_addr = "%s/%s" % (d['ip'], if_nm[1])
             if_gw = d['default_gateway']
+            if_gw = d['default_gateway']
+	    if_mtu = None
+	    if 'mtu' in d and d['mtu']:
+	    	if_mtu = d['mtu']
+	    else:
+		if_mtu = 1500
 
             cmd_con_down = "nmcli con down %s" % if_name
             r, err = command.get_command_output(cmd_con_down)
             if err:
                 raise Exception(err)
 
-            cmd_set_ip = 'nmcli con mod %s ipv4.method manual connection.autoconnect yes connection.autoconnect-priority 99 connection.autoconnect-slaves 1 ipv4.never-default no ipv4.addresses %s ipv4.gateway %s ipv4.routes "%s %s"' % (
-                if_name, if_addr, if_gw, if_nm_route, if_gw)
+            cmd_set_ip = 'nmcli con mod %s ipv4.method manual connection.autoconnect yes connection.autoconnect-priority 99 connection.autoconnect-slaves 1 ipv4.never-default no ipv4.addresses %s ipv4.gateway %s ipv4.routes "%s %s" 802-3-ethernet.mtu %s' % (
+                if_name, if_addr, if_gw, if_nm_route, if_gw, if_mtu)
             r, err = command.get_command_output(cmd_set_ip)
             if err:
                 raise Exception(err)
@@ -984,6 +990,11 @@ def update_interface_ip(if_name, d):
             if_nm = if_nm.split("/")
             if_addr = "%s/%s" % (d['ip'], if_nm[1])
             if_gw = d['default_gateway']
+	    if_mtu = None
+	    if 'mtu' in d and d['mtu']:
+	    	if_mtu = d['mtu']
+	    else:
+		if_mtu = 1500
 
             cmd_assert_con = 'nmcli con show %s' % if_name
             assert_con, err = command.get_command_output(cmd_assert_con)
@@ -998,8 +1009,8 @@ def update_interface_ip(if_name, d):
             cmd_con_down = "nmcli con down %s" % if_name
             r, err = command.get_command_output(cmd_con_down)
 
-            cmd_set_ip = 'nmcli con mod %s ipv4.method manual connection.autoconnect yes ipv4.never-default no ipv4.addresses %s ipv4.gateway %s ipv4.routes "%s %s"' % (
-                if_name, if_addr, if_gw, if_nm_route, if_gw)
+            cmd_set_ip = 'nmcli con mod %s ipv4.method manual connection.autoconnect yes ipv4.never-default no ipv4.addresses %s ipv4.gateway %s ipv4.routes "%s %s" 802-3-ethernet.mtu %s' % (
+                if_name, if_addr, if_gw, if_nm_route, if_gw, if_mtu)
             r, err = command.get_command_output(cmd_set_ip)
             if err:
                 raise Exception(err)


### PR DESCRIPTION
	- set persistent MTU for networking interfaces under
	  systemd

	- default MTU is set to 1500

Signed-off-by: six-k <ramsri.hp@gmail.com>