### PR TITLE
Cleanup replication

### DIFF
--- a/site-packages/integralstor_utils/scheduler_utils.py
+++ b/site-packages/integralstor_utils/scheduler_utils.py
@@ -119,6 +119,44 @@ def get_cron_tasks(cron_task_id=None, user='root'):
         return cron_list, None
 
 
+def is_task_running(cron_task_id, task_type_id, check_execution=False):
+    """Check if any entry in the tasks table with cron_task_id has
+    status field value as 'running'
+
+    args:       cron_task_id of integer type
+                task_type_id of integer type
+                check_execution of boolean type
+                    - when set, also considers 'error-retrying' and
+                    'queued' states.
+
+    returns:    (ret1, ret2) - (True/False/None, "Error_String"/None)
+                ret1:   True if a task has status as 'running', else
+                        False if no task has status as 'running', or
+                        None if exceptions were raised
+
+                ret2:   None if no exceptions were raised, else
+                        Error string 
+    """
+    is_running = False
+    try:
+        existing_tasks = None
+        existing_tasks, err = get_tasks_by_cron_task_id(cron_task_id)
+        if err is not None:
+            raise Exception(err)
+        if existing_tasks:
+            for task in existing_tasks:
+                # Check if a background task with the same cron_task_id is yet to complete its replication
+                if check_execution is True and str(task['status']) in ['running', 'queued', 'error-retrying'] and str(task['task_type_id']) == str(task_type_id):
+                    is_running = True
+                elif check_execution is False and str(task['status']) in ['running'] and str(task['task_type_id']) == str(task_type_id):
+                    is_running = True
+
+    except Exception, e:
+        return None, str(e)
+    else:
+        return is_running, None
+
+
 def delete_cron(cron_task_id, user='root'):
     """Delete a cron by the cron_task_id."""
     try:
@@ -417,7 +455,8 @@ def process_tasks(node=socket.getfqdn()):
                         break
 
                     # Now actually execute the command
-                    # This task is not to be meant to be executed by the current user so switch to that user
+                    # This task is not to be meant to be executed by the
+                    # current user so switch to that user
                     (out, return_code), err = command.execute_with_rc(
                         subtask["command"], shell=True, run_as_user_name=run_as_user_name)
 
@@ -518,7 +557,8 @@ def main():
     # print get_background_jobs(db_path,node='gridcell-pri.integralstor.lan')
     # print delete_task(5)
     # print run_from_shell()
-    print delete_all_tasks()
+    # print delete_all_tasks()
+    print is_task_running(1)
 
 
 if __name__ == "__main__":

--- a/site-packages/integralstor_utils/scheduler_utils.py
+++ b/site-packages/integralstor_utils/scheduler_utils.py
@@ -243,8 +243,9 @@ def delete_task(task_id):
         db_path, err = config.get_db_path()
         if err:
             raise Exception(err)
-        cmd_list = [['delete from tasks where task_id = %s' % task_id], [
-            'delete from subtasks where task_id = %s' % task_id]]
+        # Deleting entries from tasks table will also remove related
+        # entries in subtasks table; cascading deletions.
+        cmd_list = [['delete from tasks where task_id = %s' % task_id], ]
 
         status, err = db.execute_iud(db_path, cmd_list)
         if err:
@@ -263,8 +264,9 @@ def delete_all_tasks():
         db_path, err = config.get_db_path()
         if err:
             raise Exception(err)
-        cmd_list = [['delete from tasks'], [
-            'delete from subtasks']]
+        # Deleting entries from tasks table will also remove related
+        # entries in subtasks table; cascading deletions.
+        cmd_list = [['delete from tasks'], ]
 
         status, err = db.execute_iud(db_path, cmd_list)
         if err:
@@ -455,8 +457,7 @@ def process_tasks(node=socket.getfqdn()):
                         break
 
                     # Now actually execute the command
-                    # This task is not to be meant to be executed by the
-                    # current user so switch to that user
+                    # This task is not meant to be executed by the current user so switch to that user
                     (out, return_code), err = command.execute_with_rc(
                         subtask["command"], shell=True, run_as_user_name=run_as_user_name)
 


### PR DESCRIPTION
### Cascade subtasks deletions with tasks deletions
    
    When an entry from tasks table is deleted, delete the relevant entries
    from subtasks table as well.
    
    Previously, deletion of tasks table entries were followed by deletions
    of subtasks table entires. This order will have to be reversed since
    task_id of tasks table is a foreign key in subtasks table. Defaulting
    the cascading deletes to be handled by sqlite is a better choice over
    reversing the order.

### Add function is_task_running
    
    A function to check if any of the scheduled tasks is currently
    'running'

